### PR TITLE
Remove search_history_controller.rb override

### DIFF
--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,6 +1,0 @@
-class SearchHistoryController < ApplicationController
-  include Blacklight::SearchHistory
-
-  helper BlacklightRangeLimit::ViewHelperOverride
-  helper RangeLimitHelper
-end


### PR DESCRIPTION
This referenced classes that no longer exist; only failed in production.